### PR TITLE
Omit Fields From Mappings

### DIFF
--- a/eventBuffer/_createIndex.js
+++ b/eventBuffer/_createIndex.js
@@ -1,5 +1,6 @@
 var argv = require('../argv');
 var client = require('../_client');
+var omitFields = require('./_omitFields');
 
 module.exports = function createIndex(indexName) {
   argv.log('ensuring index "%s" exists', indexName);
@@ -53,7 +54,7 @@ module.exports = function createIndex(indexName) {
           enabled: true,
           store: 'yes'
         },
-        properties: {
+        properties: omitFields({
           '@timestamp': {
             type: 'date'
           },
@@ -116,7 +117,7 @@ module.exports = function createIndex(indexName) {
               }
             }
           }
-        }
+        }, true)
       }
     }
   };

--- a/eventBuffer/_omitFields.js
+++ b/eventBuffer/_omitFields.js
@@ -8,9 +8,10 @@ if (!argv.omit) {
 
 var paths = (_.isArray(argv.omit) ? argv.omit : [argv.omit]).map(parseStringPropertyPath);
 
-module.exports = function (event) {
+module.exports = function (body, isFieldMap) {
+  isFieldMap = !!isFieldMap;
   paths.forEach(function (path) {
-    unDefine(event.body, path);
+    unDefine(body, path);
   });
 
   function unDefine(obj, path) {
@@ -27,7 +28,12 @@ module.exports = function (event) {
       walkIn(next, path);
     }
     else if (next) {
-      unDefine(next, path);
+      // FIXME Make this prettier
+      if(isFieldMap) {
+        unDefine(next.properties, path);
+      } else {
+        unDefine(next, path);
+      }
     }
 
     path.unshift(step);
@@ -41,7 +47,7 @@ module.exports = function (event) {
     });
   }
 
-  return event;
+  return body;
 };
 
 

--- a/eventBuffer/index.js
+++ b/eventBuffer/index.js
@@ -9,7 +9,8 @@ eventBuffer.push = function (event) {
   if (event === false) {
     eventBuffer.final = true;
   } else {
-    Array.prototype.push.call(eventBuffer, omitFields(event));
+    omitFields(event.body);
+    Array.prototype.push.call(eventBuffer, event);
   }
 
   if (eventBuffer.length === 3000 || eventBuffer.final) {


### PR DESCRIPTION
Closes #10.

Changed omit to make up for the fact field mappings when nested have the properties key.

Need to check Arrays.